### PR TITLE
fix: bumps eslint-plugin-jest-dom peer dependency to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": ">= 7.0.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^27.0.0",
-    "eslint-plugin-jest-dom": "^3.0.0",
+    "eslint-plugin-jest-dom": "^4.0.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
This change should have made it into #16 RIP